### PR TITLE
feat(infrastructure): implement a decoupled infrastructure approach

### DIFF
--- a/app/Providers/InfrastructureServiceProvider.php
+++ b/app/Providers/InfrastructureServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Architecture\Infrastructure\Adapters\AuthAdapterInterface;
+use Architecture\Infrastructure\Adapters\AuthAdapterLaravel;
+use Architecture\Infrastructure\Adapters\ConfigAdapterInterface;
+use Architecture\Infrastructure\Adapters\ConfigAdapterLaravel;
+use Architecture\Infrastructure\Adapters\TranslatorAdapterInterface;
+use Architecture\Infrastructure\Adapters\TranslatorAdapterLaravel;
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
+
+class InfrastructureServiceProvider extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * Register any infrastructure services.
+     */
+    public function register(): void
+    {
+        $this->app->bind(AuthAdapterInterface::class, AuthAdapterLaravel::class);
+        $this->app->bind(ConfigAdapterInterface::class, ConfigAdapterLaravel::class);
+        $this->app->bind(TranslatorAdapterInterface::class, TranslatorAdapterLaravel::class);
+    }
+
+    public function provides(): array
+    {
+        return [
+            AuthAdapterInterface::class,
+            ConfigAdapterInterface::class,
+            TranslatorAdapterInterface::class,
+        ];
+    }
+}

--- a/architecture/Infrastructure/Adapters/AuthAdapterInterface.php
+++ b/architecture/Infrastructure/Adapters/AuthAdapterInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Architecture\Infrastructure\Adapters;
+
+interface AuthAdapterInterface
+{
+    public function login(array $credentials, bool $remember = false): bool;
+
+    public function validate(array $credentials): bool;
+
+    public function loginOnce(array $credentials): bool;
+
+    public function logout(): void;
+
+    public function isUser(): bool;
+
+    public function isGuest(): bool;
+
+    public function getUser(): ?array;
+}

--- a/architecture/Infrastructure/Adapters/AuthAdapterLaravel.php
+++ b/architecture/Infrastructure/Adapters/AuthAdapterLaravel.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Architecture\Infrastructure\Adapters;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+
+class AuthAdapterLaravel implements AuthAdapterInterface
+{
+    public function login(array $credentials, bool $remember = false): bool
+    {
+        return Auth::attempt($credentials, $remember);
+    }
+
+    public function validate(array $credentials): bool
+    {
+        return Auth::validate($credentials);
+    }
+
+    public function loginOnce(array $credentials): bool
+    {
+        return Auth::once($credentials);
+    }
+
+    public function logout(): void
+    {
+        Auth::logout();
+    }
+
+    public function isUser(): bool
+    {
+        return Auth::check();
+    }
+
+    public function isGuest(): bool
+    {
+        return Auth::guest();
+    }
+
+    public function getUser(): ?array
+    {
+        $user = Auth::user();
+
+        return match (true) {
+            $user instanceof Model => $user->toArray(),
+
+            $user instanceof Authenticatable => [
+                $user->getAuthIdentifierName() => $user->getAuthIdentifier(),
+                $user->getAuthPasswordName() => $user->getAuthPassword(),
+                $user->getRememberTokenName() => $user->getRememberToken(),
+            ],
+
+            default => null,
+        };
+    }
+}

--- a/architecture/Infrastructure/Adapters/ConfigAdapterInterface.php
+++ b/architecture/Infrastructure/Adapters/ConfigAdapterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Architecture\Infrastructure\Adapters;
+
+interface ConfigAdapterInterface
+{
+    public function get(string $key, mixed $default = null): mixed;
+}

--- a/architecture/Infrastructure/Adapters/ConfigAdapterLaravel.php
+++ b/architecture/Infrastructure/Adapters/ConfigAdapterLaravel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Architecture\Infrastructure\Adapters;
+
+class ConfigAdapterLaravel implements ConfigAdapterInterface
+{
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return config($key, $default);
+    }
+}

--- a/architecture/Infrastructure/Adapters/TranslatorAdapterInterface.php
+++ b/architecture/Infrastructure/Adapters/TranslatorAdapterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Architecture\Infrastructure\Adapters;
+
+interface TranslatorAdapterInterface
+{
+    public function resolve(string $key, array $replace = [], ?string $locale = null): string|array;
+}

--- a/architecture/Infrastructure/Adapters/TranslatorAdapterLaravel.php
+++ b/architecture/Infrastructure/Adapters/TranslatorAdapterLaravel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Architecture\Infrastructure\Adapters;
+
+class TranslatorAdapterLaravel implements TranslatorAdapterInterface
+{
+    public function resolve(string $key, array $replace = [], ?string $locale = null): string|array
+    {
+        return trans($key, $replace, $locale);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\InfrastructureServiceProvider::class,
 ];


### PR DESCRIPTION
- Introduce interfaces for infrastructure adapters:
  - `ConfigAdapterInterface`
  - `AuthAdapterInterface`
  - `TranslatorAdapterInterface`
- Implement Laravel-specific adapters for these interfaces.
- Add `InfrastructureServiceProvider` to bind interfaces to implementations.
- Register `InfrastructureServiceProvider` in the application.

This change establishes a decoupled approach in the infrastructure layer, reducing tight coupling to Laravel and enabling greater flexibility, testability, and maintainability.